### PR TITLE
[meta] Rename to a4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gambit"
+name = "a4"
 version = "0.1.0"
 authors = ["Sean Gillespie <sean@swgillespie.me>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Gambit - A Chess Engine
+# a4 - A Chess Engine
 
-`gambit` is a (work-in-progress) chess engine. It is the fourth incarnation of the `apollo` family of chess engines:
+`a4` is a (work-in-progress) chess engine. It is the fourth incarnation of the `apollo` family of chess engines:
 
 1. [swgillespie/apollo](https://github.com/swgillespie/apollo) contains versions one and two of the `apollo` engine,
    both written in Rust. Version 1 never played chess, but implemented the rules correctly. Version 2 plays chess at
@@ -9,32 +9,32 @@
 2. [swgillespie/apollo3](https://github.com/swgillespie/apollo3) contains version three of the `apollo` engine, this
    time written in C++. Version 3 played chess at a beginner level but was riddled with bugs in its search code.
 
-As the fourth incarnation of `apollo`, `gambit` aims to synthesize all of my learnings from its previous lives and come
-away with a stronger chess engine. `gambit` cribbed a lot of code from `apollo` v2.
+As the fourth incarnation of `apollo`, `a4` aims to synthesize all of my learnings from its previous lives and come
+away with a stronger chess engine. `a4` cribbed a lot of code from `apollo` v2.
 
 I've been working on the `apollo` family of chess engines on and off for four years. When I first learned to program the
 first large program I attempted to write was a chess engine, but at the time I wasn't a skilled enough programmer to
 pull it off. Chess programming is near and dear to my heart and I have a ton of fun hacking on this project.
 
-Some technical details and decisions about `gambit`, as informed by its previous lives:
+Some technical details and decisions about `a4`, as informed by its previous lives:
 
-1. `gambit` is a **copy-make** engine. There are two approaches to applying a move to a chess position; either you copy
+1. `a4` is a **copy-make** engine. There are two approaches to applying a move to a chess position; either you copy
    the game state and destructively modify it to reflect the move, or you incrementally update the game state and *unmake*
    any changes you made to undo the move. If you think about it, in theory copy-make is probably slower than make-unmake,
-   but `apollo3` was a make-unmake and it was slower than `apollo2`. I implemented make-unmake in `gambit`, measured it,
+   but `apollo3` was a make-unmake and it was slower than `apollo2`. I implemented make-unmake in `a4`, measured it,
    and found that Rust's `clone` implementation beats it no matter how much I optimize `unmake`. Furthermore, the `unmake`
    function is hard to write and hard to get correct, while `clone` is obvious and impossible to mess up.
-2. `gambit` is a **UCI** engine. UCI is the standard protocol for chess GUIs to interact with engines. It's what Stockfish
+2. `a4` is a **UCI** engine. UCI is the standard protocol for chess GUIs to interact with engines. It's what Stockfish
    uses, and if it's good enough for Stockfish, it's good enough for me. There's also a bunch of nice tooling for engines
    that speak UCI such as integration into chess GUIs (so you can actually play the bot) to scripting. `apollo` v2 had a
    program that hosted two copies of itself and made them play eachother, for testing changes that could influence the
    strength of the engine.
-3. `gambit` is **parallel**. Chess is a famously hard problem to parallelize. The strategy that `gambit` aims to use
+3. `a4` is **parallel**. Chess is a famously hard problem to parallelize. The strategy that `a4` aims to use
    is dubbed **Lazy-SMP**; the goal is to have a single shared hashtable data structure that caches information about
    specific positions (the *transposition table*) and have a number of threads search using it. It's not the most
    theoretically beautiful algorithm, but it does produce effective speedups on a SMP machine. apollo v2 attempted to
    parallelize its search using `rayon` and `crossbeam`, but this proved difficult to get correct and `rayon`'s use
    of small tasks is not particularly well-suited to the problem of searching chess positions.
 
-Gambit's current state is that it fully implements the game of chess (with lots of tests). Evaluation and search is
+a4's current state is that it fully implements the game of chess (with lots of tests). Evaluation and search is
 currently in progress. Code for dealing with UCI is likely to be lifted directly from `apollo` v2.

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -7,9 +7,9 @@
 // except according to those terms.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use gambit::core::{self, Color, Move};
-use gambit::movegen;
-use gambit::Position;
+use a4::core::{self, Color, Move};
+use a4::movegen;
+use a4::Position;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("quiet-move-clonemake", |b| {

--- a/src/bin/a4-eval.rs
+++ b/src/bin/a4-eval.rs
@@ -8,8 +8,8 @@
 
 use structopt::StructOpt;
 
-use gambit::eval;
-use gambit::Position;
+use a4::eval;
+use a4::Position;
 
 #[derive(Debug, StructOpt)]
 struct Options {

--- a/src/bin/a4-moves.rs
+++ b/src/bin/a4-moves.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 
-use gambit::movegen;
-use gambit::Position;
+use a4::movegen;
+use a4::Position;
 
 #[derive(Debug, StructOpt)]
 struct Options {

--- a/src/bin/a4-perft.rs
+++ b/src/bin/a4-perft.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 
-use gambit::movegen;
-use gambit::Position;
+use a4::movegen;
+use a4::Position;
 
 #[derive(Debug, StructOpt)]
 struct Options {

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Module `core` contains core datatypes and data structures used pervasively throughout `gambit`.
+//! Module `core` contains core datatypes and data structures used pervasively throughout `a4`.
 
 mod attacks;
 mod r#move;

--- a/src/core/move.rs
+++ b/src/core/move.rs
@@ -17,7 +17,7 @@ const SPECIAL_0_BIT: u16 = 0x0002;
 const SPECIAL_1_BIT: u16 = 0x0001;
 const ATTR_MASK: u16 = 0x000F;
 
-/// A move, recognized by the gambit engine. It is designed to be as
+/// A move, recognized by the a4 engine. It is designed to be as
 /// compact as possible.
 /// ## Encoding
 /// The encoding of a move is done via this breakdown:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! The `gambit` chess engine and library, at your service!
+//! The `a4` chess engine and library, at your service!
 //!
-//! `gambit` aims to be a one-stop shop for Chess programming in Rust. As a library, `gambit` is capable of analyzing
-//! positions, reading and writing common Chess formats, and manipulating board positions. As an executable, `gambit`
+//! `a4` aims to be a one-stop shop for Chess programming in Rust. As a library, `a4` is capable of analyzing
+//! positions, reading and writing common Chess formats, and manipulating board positions. As an executable, `a4`
 //! is capable of playing chess via the `UCI` protocol.
 
 pub mod core;

--- a/tests/run.py
+++ b/tests/run.py
@@ -31,7 +31,7 @@ def run_perft_test(test):
     count = int(
         subprocess.check_output(
             [
-                "./target/release/gambit-perft",
+                "./target/release/a4-perft",
                 test["fen"],
                 "--depth",
                 str(test["depth"]),


### PR DESCRIPTION
This commit switches the name to `a4`, combining with another project that's the
fourth incarnation of the `apollo` series of engines.
