### PR TITLE
[search] Add a4-search binary for position search

### DIFF
--- a/src/bin/a4-search.rs
+++ b/src/bin/a4-search.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Sean Gillespie.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use a4::{search, Position};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Options {
+    /// FEN representation of the position to analyze.
+    #[structopt(name = "FEN")]
+    fen: String,
+    /// Depth to which to search
+    #[structopt(short, long)]
+    depth: u32,
+    /// If present, serializes the output as json.
+    #[structopt(long)]
+    json: bool,
+}
+
+fn main() {
+    let ops = Options::from_args();
+    let pos = Position::from_fen(ops.fen).unwrap();
+    let result = search::search(&pos, ops.depth);
+    if ops.json {
+        println!(
+            "{{
+    \"best_move\": \"{}\",
+    \"best_score\": {},
+    \"nodes_evaluated\": {},
+}}",
+            result.best_move, result.best_score, result.nodes_evaluated
+        );
+    } else {
+        println!("{:?}", result);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,6 @@ pub mod core;
 pub mod eval;
 pub mod movegen;
 mod position;
-mod search;
+pub mod search;
 
 pub use position::Position;

--- a/src/search.rs
+++ b/src/search.rs
@@ -14,6 +14,7 @@ struct Searcher {
     nodes_evaluated: u32,
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct SearchResult {
     pub best_move: Move,
     pub best_score: Value,


### PR DESCRIPTION
a4-search takes in a FEN and depth and runs the search routine. The goal
is to provide a simple CLI that we can script via unit tests to ensure
that the search behaves reasonably in a variety of circumstances.
