### PR TITLE
[threads] Hook up UCI and threads layers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,13 @@ authors = ["Sean Gillespie <sean@swgillespie.me>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.44"
 thiserror = "1.0.23" 
 bitflags = "1.2.1"
 lazy_static = "1.4.0"
 structopt = "0.3.21"
+tracing = "0.1.28"
+tracing-subscriber = "0.2.24"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bin/a4.rs
+++ b/src/bin/a4.rs
@@ -7,7 +7,14 @@
 // except according to those terms.
 
 use a4::uci;
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
 
 fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
     uci::run().expect("fatal error while running UCI server");
 }

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -16,28 +16,40 @@
 #![allow(dead_code)] // Lots of this code will be used elsewhere in time.
 
 use std::{
+    cell::RefCell,
     sync::{
+        atomic::{AtomicBool, Ordering},
         mpsc::{self, Receiver, SyncSender},
-        Once,
+        Condvar, Mutex, Once, RwLock,
     },
     thread::{self, JoinHandle},
+    time::Duration,
 };
+use tracing::Level;
+
+use crate::Position;
 
 /// External interface to the thread pool.
 pub struct Threads {
     main_thread: MainThread,
+    worker_threads: Vec<WorkerThread>,
 }
 
 impl Threads {
     fn new() -> Threads {
         Threads {
             main_thread: MainThread::new(),
+            worker_threads: vec![WorkerThread::new()],
         }
     }
 
     /// Gets a reference to the main thread, for the purposes of sending messages to it.
     pub fn main_thread(&self) -> &MainThread {
         &self.main_thread
+    }
+
+    pub fn worker_threads(&self) -> &[WorkerThread] {
+        &self.worker_threads
     }
 }
 
@@ -59,17 +71,21 @@ pub fn get() -> &'static Threads {
 enum Request {
     Ping,
     Shutdown,
+    Search,
+    Stop,
 }
 
 enum Response {
     Ping,
     Shutdown,
+    Stop,
 }
 
 pub struct MainThread {
     handle: JoinHandle<()>,
     request_tx: SyncSender<Request>,
     response_rx: Receiver<Response>,
+    position: RwLock<Position>,
 }
 
 impl MainThread {
@@ -87,6 +103,7 @@ impl MainThread {
             handle,
             request_tx,
             response_rx,
+            position: RwLock::new(Position::new()),
         }
     }
 
@@ -101,6 +118,18 @@ impl MainThread {
         true
     }
 
+    pub fn search(&self) {
+        self.request_tx
+            .send(Request::Search)
+            .expect("search failed to send on request tx");
+    }
+
+    pub fn stop(&self) {
+        self.request_tx
+            .send(Request::Stop)
+            .expect("stop failed to send on request tx");
+    }
+
     pub fn shutdown(self) {
         self.request_tx
             .send(Request::Shutdown)
@@ -111,10 +140,16 @@ impl MainThread {
             .expect("shutdown failed to recv on request rx");
         self.handle.join().expect("failed to join loop thread");
     }
+
+    pub fn set_position(&self, pos: Position) {
+        *self.position.write().unwrap() = pos;
+    }
 }
 
 fn thread_loop(rx: Receiver<Request>, tx: SyncSender<Response>) {
+    let _span = tracing::span!(Level::INFO, "main_thread").entered();
     let loop_result: Result<(), mpsc::SendError<Response>> = try {
+        tracing::debug!("entering main loop");
         while let Ok(req) = rx.recv() {
             match req {
                 Request::Ping => tx.send(Response::Ping)?,
@@ -122,11 +157,135 @@ fn thread_loop(rx: Receiver<Request>, tx: SyncSender<Response>) {
                     tx.send(Response::Shutdown)?;
                     return;
                 }
+                Request::Search => {
+                    tracing::debug!("sending start signal to workers");
+                    for worker in get().worker_threads() {
+                        worker.start();
+                    }
+                }
+                Request::Stop => {
+                    for worker in get().worker_threads() {
+                        worker.stop();
+                    }
+                }
             }
         }
     };
 
     loop_result.expect("failed to send response to calling thread");
+}
+
+pub struct WorkerThread {
+    handle: JoinHandle<()>,
+    idle_lock: Mutex<bool>,
+    idle_cv: Condvar,
+    stop_flag: AtomicBool,
+    shutdown_flag: AtomicBool,
+}
+
+impl WorkerThread {
+    pub fn new() -> WorkerThread {
+        let handle = thread::Builder::new()
+            .name("a4 worker thread".into())
+            .spawn(|| {
+                THREAD_KIND.with(|kind| *kind.borrow_mut() = ThreadIdentifier::WorkerThread(0));
+                worker_thread_loop()
+            })
+            .expect("failed to spawn main thread");
+
+        WorkerThread {
+            handle,
+            idle_lock: Mutex::new(true),
+            idle_cv: Condvar::new(),
+            stop_flag: AtomicBool::new(false),
+            shutdown_flag: AtomicBool::new(false),
+        }
+    }
+
+    pub fn shutdown(self) {
+        self.stop_flag.store(true, Ordering::Release);
+        self.shutdown_flag.store(true, Ordering::Release);
+        self.start();
+        self.handle.join().unwrap();
+    }
+
+    pub fn start(&self) {
+        let mut idle = self.idle_lock.lock().unwrap();
+        *idle = false;
+        self.idle_cv.notify_one();
+    }
+
+    pub fn stop(&self) {
+        self.stop_flag.store(true, Ordering::Release);
+    }
+}
+
+fn worker_thread_loop() {
+    let (id, thread) = current().unwrap_worker();
+    let _span = tracing::span!(Level::DEBUG, "worker_thread", id).entered();
+    tracing::debug!("entering main loop");
+    loop {
+        tracing::debug!("waiting for start signal");
+        let idle = thread.idle_lock.lock().unwrap();
+        let mut idle = thread.idle_cv.wait_while(idle, |idle| *idle).unwrap();
+        if thread.shutdown_flag.load(Ordering::Acquire) {
+            tracing::debug!("received shutdown signal, terminating");
+            return;
+        }
+
+        tracing::debug!("worker becoming active");
+        while !thread.stop_flag.load(Ordering::Acquire) {
+            println!("doing work!");
+            thread::sleep(Duration::from_secs(1));
+        }
+
+        tracing::debug!("worker received stop signal");
+        thread.stop_flag.store(false, Ordering::Release);
+        *idle = true;
+    }
+}
+
+enum ThreadIdentifier {
+    MainThread,
+    WorkerThread(usize),
+    Unknown,
+}
+
+enum ThreadKind {
+    Main(&'static MainThread),
+    Worker(usize, &'static WorkerThread),
+    Unknown,
+}
+
+impl ThreadKind {
+    pub fn unwrap_main(self) -> &'static MainThread {
+        match self {
+            ThreadKind::Main(thread) => thread,
+            ThreadKind::Worker(_, _) => panic!("unwrap_main() called on worker thread"),
+            ThreadKind::Unknown => panic!("unwrap_main() called on unknown thread"),
+        }
+    }
+
+    pub fn unwrap_worker(self) -> (usize, &'static WorkerThread) {
+        match self {
+            ThreadKind::Main(_) => panic!("unwrap_worker() called on main thread"),
+            ThreadKind::Worker(id, thread) => (id, thread),
+            ThreadKind::Unknown => panic!("unwrap_main() called on unknown thread"),
+        }
+    }
+}
+
+thread_local! {
+    static THREAD_KIND: RefCell<ThreadIdentifier> = RefCell::new(ThreadIdentifier::Unknown);
+}
+
+fn current() -> ThreadKind {
+    let threads = get();
+    THREAD_KIND.with(|kind| match *kind.borrow() {
+        ThreadIdentifier::MainThread => ThreadKind::Main(threads.main_thread()),
+        ThreadIdentifier::WorkerThread(id) => ThreadKind::Worker(id, &threads.worker_threads()[id]),
+        ThreadIdentifier::Unknown => ThreadKind::Unknown,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We can now dispatch work to background threads asynchronously, which
we'll eventually use to dispatch search routines to worker threads.
