### PR TITLE
Add GDB helper script

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -8,7 +8,7 @@
 
 //! A collection of debug utilities that are either executable directly from a debugger or invoke the debugger
 //! throughout the course of execution.
-use std::{hint::black_box, ptr};
+use std::{ffi::CString, hint::black_box, ptr};
 
 use crate::{core::Move, eval::Value, position::Position};
 
@@ -20,20 +20,26 @@ pub extern "C" fn pos_str(pos: *const Position) {
 }
 
 #[no_mangle]
-pub extern "C" fn pos_fen(pos: *const Position) {
+pub extern "C" fn pos_fen(pos: *const Position) -> *const i8 {
     // assumption: `pos` was derived from a Rust reference and thus is not null.
     let pos = unsafe { &*pos };
-    println!("{}", pos.as_fen());
+    let body = CString::new(format!("{}", pos.as_fen())).unwrap();
+    let leaked = Box::leak(body.into_boxed_c_str());
+    return leaked.as_ptr();
 }
 
 #[no_mangle]
-pub extern "C" fn value_str(value: Value) {
-    println!("{:?}", value);
+pub extern "C" fn value_str(value: Value) -> *const i8 {
+    let body = CString::new(format!("{:?}", value)).unwrap();
+    let leaked = Box::leak(body.into_boxed_c_str());
+    return leaked.as_ptr();
 }
 
 #[no_mangle]
-pub extern "C" fn move_str(mov: Move) {
-    println!("{}", mov.as_uci());
+pub extern "C" fn move_str(mov: Move) -> *const i8 {
+    let body = CString::new(format!("{}", mov.as_uci())).unwrap();
+    let leaked = Box::leak(body.into_boxed_c_str());
+    return leaked.as_ptr();
 }
 
 #[no_mangle]

--- a/tools/gdb.py
+++ b/tools/gdb.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Sean Gillespie.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+from typing import Any
+
+from gdb.printing import register_pretty_printer, RegexpCollectionPrettyPrinter
+import gdb
+
+"""
+Python extensions to GDB to assist in debugging a4.
+"""
+
+
+class ValuePrettyPrinter:
+    VALUE_MATED = -32768 // 2 + 1
+    VALUE_MATE = 32767 // 2
+    MATE_DISTANCE_MAX = 50
+
+    val: gdb.Value
+
+    def __init__(self, val: gdb.Value):
+        self.val = val
+
+    def to_string(self):
+        val = self.val.cast(
+            gdb.lookup_type("i16")
+        )  # sneakily reads the value from the debuggee process
+        if val > self.VALUE_MATE:
+            return f"#{self.VALUE_MATE + self.MATE_DISTANCE_MAX - val}"
+        elif val < self.VALUE_MATED:
+            return f"#-{val - self.VALUE_MATED + self.MATE_DISTANCE_MAX}"
+        return f"{val}"
+
+
+def build_pretty_printers():
+    pp = RegexpCollectionPrettyPrinter("a4")
+    # haven't found a way to print these two yet without segfaulting gdb
+    # pp.add_printer("move", "^a4::core::move::Move$", MovePrettyPrinter)
+    # pp.add_printer("position", "^\*mut a4::position::Position$", PositionPrettyPrinter)
+    pp.add_printer("value", "^a4::eval::value::Value$", ValuePrettyPrinter)
+    return pp
+
+
+register_pretty_printer(gdb.current_objfile(), build_pretty_printers())


### PR DESCRIPTION
This commit adds a value pretty-printer to GDB so that we can inspect alpha and beta as part of the stack trace.
